### PR TITLE
raycast click to place target marker on grid @CRP-002

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,15 @@
 // Three
 import * as THREE from 'three';
-// Scene
+// Scene, Camera, Lights
 import { Scene } from './scene/Scene';
 import { Camera } from './cameras/Camera';
 import { Lights } from './lights/Lights';
-// GLTF
+// Models
 import { AnimatedModel } from './models/AnimatedModel';
-// Mesh
 import { Grid } from './models/Grid';
+import { TargetMarker } from './models/TargetMarker';
+// Animation
+import { PathToTarget } from './animation/PathToTarget';
 // Renderer
 import { Renderer } from './renderer/Renderer';
 // Character & Animation configs
@@ -32,6 +34,16 @@ export const App = () => {
   // MESH
   const floor = Grid();
   scene.add(floor.mesh);
+  const targetMarker = TargetMarker();
+  scene.add(targetMarker.mesh);
+  // PATH TO TARGET
+  const pathToTarget = PathToTarget({
+    meshToIntersect: floor.mesh,
+    meshToMove: cat.mesh,
+    meshTargetMarker: targetMarker.mesh,
+    scene: scene.self,
+    camera: camera.self
+  });
   // RENDERER
   const renderer = Renderer();
   document.body.appendChild(renderer.domElement);

--- a/src/animation/PathToTarget.js
+++ b/src/animation/PathToTarget.js
@@ -1,0 +1,58 @@
+// Three
+import * as THREE from 'three';
+
+
+//////////
+// BEGIN
+export const PathToTarget = ({
+  meshToIntersect,
+  meshToMove,
+  meshTargetMarker,
+  scene,
+  camera
+}) => {
+  const _raycaster = new THREE.Raycaster();
+	const _pointer = new THREE.Vector2();
+  let _isEnabled;
+  let _intersected;
+  setEnabled(true);
+
+  function setEnabled (isEnabled) {
+    _isEnabled = isEnabled;
+    if (_isEnabled === true) {
+      window.addEventListener('click', getTarget, { capture: true });
+    } else {
+      window.removeEventListener('click', getTarget, { capture: true });
+    }
+  }
+
+
+  function getTarget (event) {
+    event.preventDefault();
+    // calculate pointer position in normalized device coordinates
+	  // (-1 to +1) for both components
+    _pointer.x = ( event.clientX / window.innerWidth ) * 2 - 1;
+    _pointer.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+    // update the picking ray with the camera and pointer position
+	  _raycaster.setFromCamera( _pointer, camera );
+    // calculate objects intersecting the picking ray
+	  const _intersects = _raycaster.intersectObjects( scene.children, false );
+    // reset _intersected flag
+    _intersected = null;
+    if (_intersects.length === 0) return;
+    for ( let i = 0; i < _intersects.length; i ++ ) {
+      if (_intersects[i].object.name === meshToIntersect.name) {
+        _intersected = _intersects[i];
+        break;
+      }
+    }
+    if (_intersected !== null) {
+      meshTargetMarker.position.x = _intersected.point.x;
+      meshTargetMarker.position.z = _intersected.point.z;
+    }
+  }
+
+  return {
+    setEnabled
+  }
+}

--- a/src/models/Grid.js
+++ b/src/models/Grid.js
@@ -4,6 +4,7 @@ export function Grid() {
   const material = new THREE.LineBasicMaterial({
     color: 0x00ff00
   });
+
   
   const lineWidth = 18;
   const lineSegments = 18;
@@ -20,9 +21,18 @@ export function Grid() {
   
   const geometry = new THREE.BufferGeometry().setFromPoints( points );
   
-  const mesh = new THREE.LineSegments( geometry, material );
+  const _gridMesh = new THREE.LineSegments( geometry, material );
+  _gridMesh.rotateX(-Math.PI / 2);
+
+  // Invisible raycast target
+  const _parentMesh = new THREE.Mesh( new THREE.PlaneGeometry( lineWidth, lineSegments ));
+  _parentMesh.material.transparent = true;
+  _parentMesh.material.opacity = 0;
+  _parentMesh.rotateX(-Math.PI / 2);
+  _parentMesh.name = 'floor';
+  _parentMesh.add(_gridMesh);
   
   return {
-    get mesh() { return mesh }
+    get mesh() { return _parentMesh }
   }
 }

--- a/src/models/TargetMarker.js
+++ b/src/models/TargetMarker.js
@@ -1,0 +1,11 @@
+import * as THREE from 'three';
+
+export function TargetMarker() {
+  const material = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+  const geometry = new THREE.SphereGeometry(.1);
+  const mesh = new THREE.Mesh( geometry, material );
+
+  return {
+    get mesh() { return mesh }
+  }
+}

--- a/src/renderer/Renderer.js
+++ b/src/renderer/Renderer.js
@@ -4,7 +4,6 @@ export function Renderer() {
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true } );
   renderer.setPixelRatio( window.devicePixelRatio );
   renderer.setSize( window.innerWidth, window.innerHeight );
-  renderer.outputEncoding = THREE.sRGBEncoding;
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 


### PR DESCRIPTION
Add indivisible parent plane to Grid mesh to capture Raycaster click and place red target marker.
 
![catmull-rom-path-target](https://github.com/patrick-s-young/three-catmull-rom-path-animation/assets/42591798/2471e4fc-fdb1-481f-8554-9d648b295f87)
